### PR TITLE
Remove size parameter and introduce aspect ratio mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,19 +353,6 @@ Supports multiple transports:
 
 ---
 
-## 🛟 Troubleshooting & FAQ
-
-**Which size does `S | M | L` map to?**  
-Sizes are normalized; exact pixel dimensions vary by provider.
-
-**Can I mask with Gemini or Imagen?**  
-Masking is not currently supported on those engines; use OpenAI/Azure for masking.
-
-**How do I discover what’s live right now?**  
-Call `get_model_capabilities` (optionally with `"provider": "openai"` etc.).
-
----
-
 ## ⚠️ Testing remarks
 
 I tested this project locally using the `openrouter`-backed model only. I could not access Gemini or OpenAI from my location (Hong Kong) due to regional restrictions — thanks, US government — so I couldn't fully exercise those providers.

--- a/image_gen_mcp/engines/ar/gemini.py
+++ b/image_gen_mcp/engines/ar/gemini.py
@@ -211,7 +211,6 @@ class GeminiAR(ImageEngine):
             prompt, augment_log = render_prompt_with_guidance(
                 prompt=req.prompt,
                 model=model,
-                size=req.size,
                 orientation=req.orientation,
                 quality=req.quality,
                 background=req.background,
@@ -263,7 +262,6 @@ class GeminiAR(ImageEngine):
             prompt, augment_log = render_prompt_with_guidance(
                 prompt=req.prompt,
                 model=model,
-                size=req.size,
                 orientation=req.orientation,
                 quality=req.quality,
                 background=req.background,

--- a/image_gen_mcp/engines/ar/openrouter.py
+++ b/image_gen_mcp/engines/ar/openrouter.py
@@ -251,14 +251,11 @@ class OpenRouterAR(ImageEngine):
             None,  # we'll fold negative_prompt into prompt guidance instead of dropping
         )
 
-        # Drop unsupported fields silently
-
         try:
             # Use XML-tagged guidance template for AR folding
             prompt, augment_log = render_prompt_with_guidance(
                 prompt=req.prompt,
                 model=model,
-                size=req.size,
                 orientation=req.orientation,
                 quality=req.quality,
                 background=req.background,
@@ -304,7 +301,6 @@ class OpenRouterAR(ImageEngine):
             prompt, augment_log = render_prompt_with_guidance(
                 prompt=req.prompt,
                 model=model,
-                size=req.size,
                 orientation=req.orientation,
                 quality=req.quality,
                 background=req.background,

--- a/image_gen_mcp/engines/diffusion/vertex_imagen.py
+++ b/image_gen_mcp/engines/diffusion/vertex_imagen.py
@@ -40,6 +40,22 @@ SCOPES = [
 # Imagen-specific enums/constants
 
 
+class ImagenAspect(StrEnum):
+    """Imagen aspect ratio mapping from unified `Orientation` enum."""
+
+    SQUARE = "1:1"
+    PORTRAIT = "9:16"
+    LANDSCAPE = "16:9"
+
+    @classmethod
+    def from_orientation(cls, orientation: Orientation | None) -> str:
+        if orientation == Orientation.PORTRAIT:
+            return cls.PORTRAIT.value
+        if orientation == Orientation.LANDSCAPE:
+            return cls.LANDSCAPE.value
+        return cls.SQUARE.value
+
+
 class ImagenErrorType(StrEnum):
     """Imagen-specific error types."""
 
@@ -212,13 +228,8 @@ class VertexImagen(ImageEngine):
         return n
 
     def _map_aspect_ratio(self, orientation: Orientation | None) -> str:
-        """Map unified orientation to Imagen aspect ratio string."""
-        if orientation == Orientation.PORTRAIT:
-            return "3:4"
-        elif orientation == Orientation.LANDSCAPE:
-            return "4:3"
-        else:
-            return "1:1"  # Default to square
+        """Map unified orientation to Imagen aspect ratio string using `ImagenAspect`."""
+        return ImagenAspect.from_orientation(orientation)
 
     # Error handling
 


### PR DESCRIPTION
### **User description**
Eliminate the size parameter from the `render_prompt_with_guidance` function to streamline the API. Introduce the `ImagenAspect` class to handle aspect ratio mapping based on orientation, enhancing clarity and maintainability.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `size` parameter from `render_prompt_with_guidance` function

- Add `ImagenAspect` class for aspect ratio mapping

- Simplify prompt guidance template structure

- Update aspect ratios to modern standards (9:16, 16:9)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["render_prompt_with_guidance"] -- "remove size param" --> B["Simplified API"]
  C["ImagenAspect class"] -- "maps orientation" --> D["Aspect ratios"]
  E["Template"] -- "restructured" --> F["Cleaner guidance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gemini.py</strong><dd><code>Remove size parameter from Gemini AR engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

image_gen_mcp/engines/ar/gemini.py

<ul><li>Remove <code>size</code> parameter from <code>render_prompt_with_guidance</code> calls in <br><code>generate</code> and <code>edit</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/simonChoi034/image-gen-mcp/pull/9/files#diff-ea17a6959f4d9679cbd3a7b8281df9fde172db85135e6d0426706c09e59478de">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openrouter.py</strong><dd><code>Remove size parameter from OpenRouter AR engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

image_gen_mcp/engines/ar/openrouter.py

<ul><li>Remove <code>size</code> parameter from <code>render_prompt_with_guidance</code> calls in <br><code>generate</code> and <code>edit</code> methods<br> <li> Remove obsolete comment about dropping unsupported fields</ul>


</details>


  </td>
  <td><a href="https://github.com/simonChoi034/image-gen-mcp/pull/9/files#diff-fac92c887b8cbb3d03cee666b1baab4551894ec17c80e39f00c4f8782b8499a6">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vertex_imagen.py</strong><dd><code>Add ImagenAspect class for aspect ratio mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

image_gen_mcp/engines/diffusion/vertex_imagen.py

<ul><li>Add <code>ImagenAspect</code> class with orientation-to-aspect-ratio mapping<br> <li> Update <code>_map_aspect_ratio</code> method to use new class<br> <li> Change aspect ratios from 3:4/4:3 to 9:16/16:9</ul>


</details>


  </td>
  <td><a href="https://github.com/simonChoi034/image-gen-mcp/pull/9/files#diff-29ab8aa4f9321a1ea1b4013e6abfbf236aa0559ab840f99a9c0c6350a8802abb">+18/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt.py</strong><dd><code>Restructure prompt guidance template and remove size handling</code></dd></summary>
<hr>

image_gen_mcp/utils/prompt.py

<ul><li>Remove <code>SizeCode</code> import and <code>size</code> parameter from function signature<br> <li> Restructure guidance template from XML-style to plain text format<br> <li> Update aspect ratios to 9:16 and 16:9 standards<br> <li> Simplify template logic and remove size-related guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/simonChoi034/image-gen-mcp/pull/9/files#diff-74fc5a5492f6df9955b86b29084d96f555c70985ee9ed6e7c9577de2d04b78fe">+22/-70</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

